### PR TITLE
Issue fix - active when typing in input element

### DIFF
--- a/easyOpen.js
+++ b/easyOpen.js
@@ -50,12 +50,15 @@ function send_open_message(actionLink) {
 		init_action_links(search_results());
 
 		document.addEventListener("keypress", function (keypressed) {
-			var ch = keypressed.key;
+			if (document.getElementById('search_input') != document.activeElement)
+			{
+				var ch = keypressed.key;
 
-			var result = action_links.find(function (actionLink) { return actionLink.character == ch; });
+				var result = action_links.find(function (actionLink) { return actionLink.character == ch; });
 
-			if (result != undefined) {
-				send_open_message(result);
+				if (result != undefined) {
+					send_open_message(result);
+				}
 			}
 		});
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
 
-  "name": "easyOpen",
+  "name": "EasyOpen",
   "description": "This extension make it easy to open search results using the keyboard",
-  "version": "1.0",
+  "version": "1.0.1",
 
   "browser_action": {
     "default_popup": "popup.html"


### PR DESCRIPTION
Fixing the issue, which EasyOpen opens the search result links when typing in the search input element.